### PR TITLE
Don't convert predictions to categories using numpy

### DIFF
--- a/everglades_species.py
+++ b/everglades_species.py
@@ -184,7 +184,7 @@ def train_model(train_path, test_path, empty_images_path=None, save_dir=".", deb
             
             comet_logger.experiment.log_parameter("saved_checkpoint","{}/species_model.pl".format(model_savedir))
             
-            ypred = results["results"].predicted_label.astype('category').cat.codes.to_numpy()            
+            ypred = results["results"].predicted_label       
             
             # Test data that does not get a bounding box is indicated by ypred == -1
             # Convert this to one more than the available class indexes to allow contruction of a confusion matrix


### PR DESCRIPTION
Due to a copy-paste error when implementing 004a1d7b73b25548ce93ff021560e4f8bbc835ab,
the code still converted predicted labels to categories using numpy
before the proper category code was executed. This removes that
incorrect initial conversion, which was breaking the confusion matrices.