### PR TITLE
Save evaluation output in correct location

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -1,5 +1,4 @@
 #DeepForest bird detection from extracted Zooniverse predictions
-import comet_ml
 from pytorch_lightning.loggers import CometLogger
 from deepforest import main
 from empty_frames_utilities import *
@@ -70,9 +69,6 @@ def evaluate_model(test_path, model_path, empty_images_path=None, save_dir=".",
     Returns:
         results: a pandas dataframe of deepforest results
     """ 
-    if experiment_name is not None:
-        comet_logger = CometLogger(project_name="everglades-species", workspace="weecology", experiment_name=experiment_name)
-    
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     model_savedir = "{}/{}".format(save_dir,timestamp)  
     

--- a/evaluate.py
+++ b/evaluate.py
@@ -168,11 +168,3 @@ def evaluate_model(test_path, model_path, empty_images_path=None, save_dir=".",
         upload_empty_images(model, comet_logger, empty_images)
 
     return model
-
-if __name__ == "__main__":
-    evaluate_model(
-                test_path="/blue/ewhite/everglades/Zooniverse/cleaned_test/test.csv",
-                save_dir="/blue/ewhite/everglades/Zooniverse/",
-                model_path="/blue/ewhite/everglades/Zooniverse//20220910_182547/species_model.pl",
-                empty_images_path="/blue/ewhite/everglades/Zooniverse/parsed_images/empty_frames.csv",
-                experiment_name="main")

--- a/evaluate.py
+++ b/evaluate.py
@@ -105,16 +105,13 @@ def evaluate_model(test_path, model_path, empty_images_path=None, save_dir=".",
     species_abbrev_lookup = get_species_abbrev_lookup(species_lookup)    
     
     results = model.evaluate("{}/cleaned_test_classes.csv".format(save_dir), root_dir = os.path.dirname(test_path))
-    
+    results["results"].to_csv("{}/iou_dataframe.csv".format(model_savedir))
+    results["predictions"].to_csv("{}/predictions_dataframe.csv".format(model_savedir))
+    results["class_recall"].to_csv("{}/class_recall.csv".format(model_savedir))
     if comet_logger is not None:
         try:
-            results["results"].to_csv("{}/iou_dataframe.csv".format(model_savedir))
             comet_logger.experiment.log_asset("{}/iou_dataframe.csv".format(model_savedir))
-
-            results["predictions"].to_csv("{}/predictions_dataframe.csv".format(model_savedir))
             comet_logger.experiment.log_asset("{}/predictions_dataframe.csv".format(model_savedir))
-            
-            results["class_recall"].to_csv("{}/class_recall.csv".format(model_savedir))
             comet_logger.experiment.log_asset("{}/class_recall.csv".format(model_savedir))
             
             for index, row in results["class_recall"].iterrows():

--- a/everglades_species.py
+++ b/everglades_species.py
@@ -173,8 +173,10 @@ def train_model(train_path, test_path, empty_images_path=None, save_dir=".",
     trainer.fit(model, dataloader)
     trainer.save_checkpoint("{}/species_model.pl".format(model_savedir))
 
-    evaluate_model(test_path=test_path, model_path="{}/species_model.pl".format(model_savedir))
-        
+    evaluate_model(test_path=test_path,
+                   model_path="{}/species_model.pl".format(model_savedir),
+                   save_dir=save_dir)
+
     return model
     
 

--- a/everglades_species.py
+++ b/everglades_species.py
@@ -175,7 +175,8 @@ def train_model(train_path, test_path, empty_images_path=None, save_dir=".",
 
     evaluate_model(test_path=test_path,
                    model_path="{}/species_model.pl".format(model_savedir),
-                   save_dir=save_dir)
+                   save_dir=save_dir,
+                   comet_logger=comet_logger)
 
     return model
     

--- a/everglades_species.py
+++ b/everglades_species.py
@@ -69,7 +69,7 @@ def train_model(train_path, test_path, empty_images_path=None, save_dir=".",
                 debug = False):
     """Train a DeepForest model"""
     
-    comet_logger = CometLogger(project_name="everglades-species", workspace="bw4sz", experiment_name=experiment_name)
+    comet_logger = CometLogger(project_name="everglades-species", workspace="weecology", experiment_name=experiment_name)
     
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     model_savedir = "{}/{}".format(save_dir,timestamp)  

--- a/experiment.sh
+++ b/experiment.sh
@@ -1,7 +1,8 @@
+sbatch <<EOT
 #!/bin/bash
 #SBATCH --job-name=EvSpecies   # Job name
 #SBATCH --mail-type=END               # Mail events
-#SBATCH --mail-user=benweinstein2010@gmail.com # Where to send mail
+#SBATCH --mail-user=ethanwhite@ufl.edu # Where to send mail
 #SBATCH --account=ewhite
 #SBATCH --nodes=1                 # Number of MPI r
 #SBATCH --cpus-per-task=30
@@ -10,8 +11,9 @@
 #SBATCH --output=/blue/ewhite/everglades/EvergladesSpeciesModel/logs/EvergladesSpeciesModel_%j.out   # Standard output and error log
 #SBATCH --error=/blue/ewhite/everglades/EvergladesSpeciesModel/logs/EvergladesSpeciesModel_%j.err
 #SBATCH --partition=gpu
-#SBATCH --gpus=a100:3
+#SBATCH --gpus=a100:1
 
 ulimit -c 0
 source activate ESM
 python everglades_species.py
+EOT


### PR DESCRIPTION
The refactor in a0c60f1 introduced some errors that prevented post fitting evaluation from running properly.
This fixes those by:

1. Saving evaluation output in the correction location
2. Writing evaluation output separately from comet logging
3. Properly passing the comet logger to the evaluation code
4. Some other minor cleanup

Fixes #32
Fixes #33